### PR TITLE
2024-12-06

### DIFF
--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -71,7 +71,8 @@
 
 - [Reconciliation Intro](./pages/React/design-pattern/ReconciliationIntro.md)
 - [문제점](./pages/React/design-pattern/ReconciliationIssue.md)
-  = [Diffing](./pages/React/design-pattern/Diffing.md)
+- [Diffing](./pages/React/design-pattern/Diffing.md)
+- [map()을 사용할 시, key에 index를 주지 않는 이유](./pages/React/design-pattern/keyInMap.md)
 
 #### extra
 

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -77,6 +77,7 @@
 #### Context api
 
 - [Context](./pages/React/design-pattern/Context.md)
+- [Wasted re-renders](./pages/React/design-pattern/WastedReRenders.md)
 
 #### extra
 

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -74,6 +74,10 @@
 - [Diffing](./pages/React/design-pattern/Diffing.md)
 - [map()을 사용할 시, key에 index를 주지 않는 이유](./pages/React/design-pattern/keyInMap.md)
 
+#### Context api
+
+- [Context](./pages/React/design-pattern/Context.md)
+
 #### extra
 
 - [ObserverPattern](./pages/React/design-pattern/ObserverPattern.md)

--- a/React-Native/pages/pages/React/design-pattern/Context.md
+++ b/React-Native/pages/pages/React/design-pattern/Context.md
@@ -1,0 +1,37 @@
+### Context
+
+- prop drilling을 방지하면서, state를 전달할 수 있음.
+- state lifting의 부작용으로 해당 스테이트가 관리되는 모든 하위 컴포넌트 리렌더링을 막을 수 있음.
+
+```jsx
+const Context = React.createContext({
+  collapsed: false,
+  toggle: () => {},
+});
+
+const useNav = () => useContext(Context);
+
+const NavController = ({ children }: { children: ReactNode }) => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const toggle = () => setCollapsed(!collapsed);
+
+  return (
+    <Context.Provider value={{ collapsed, toggle }}>
+      {children}
+    </Context.Provider>
+  );
+};
+
+export default NavController;
+```
+
+이렇게 만들면 Context를 구독하는 컴포넌트만 리렌더링 발생
+
+---
+
+#### 문제점
+
+context를 구독한는 컴포넌트라면 특정 값을 사용하지 않더라도 리렌더링이 발생한다.
+
+예를 들면 위 예서에서 `toggle()`로 setter함수만 조작하는 컴포넌트도 `collapsed` 상태가 변하면 리렌더링이 발새한다.

--- a/React-Native/pages/pages/React/design-pattern/WastedReRenders.md
+++ b/React-Native/pages/pages/React/design-pattern/WastedReRenders.md
@@ -1,0 +1,61 @@
+### Wasted Re-Renders
+
+```jsx
+const Context = React.createContext({
+  collapsed: false,
+  toggle: () => {},
+});
+
+const useNav = () => useContext(Context);
+
+const NavController = ({ children }: { children: ReactNode }) => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const toggle = useCallback(() => setCollapsed(!collapsed), [collapsed]);
+
+  const value = useMemo(() => {
+    return {
+      collapsed,
+      toggle,
+    };
+  }, [collapsed, toggle]);
+  // Memoization
+
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export default NavController;
+```
+
+- 이렇게 하면 toggle 값이 변하지 않았다 생각하여 리렌더링이 발생하니 않는다.
+- 그러나 이렇게 하더라도 collapsed state가 바뀐다면 toggle()만 사용하는 컴포넌트들도 모두 리렌더링 된다.
+
+#### 컨텍스트 분리
+
+- 데이터나 상태를 관리하는 Context와 api를 관리하는 Context를 분리한다
+
+```jsx
+const ContextData = React.createContext({
+  collapsed: false,
+});
+const ContextApi = React.createContext({
+  toggle: () => {},
+});
+
+const useNavData = () => useContext(ContextData);
+const useNavApi = () => useContext(ContextApi);
+
+const NavController = ({ children }: { children: ReactNode }) => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const toggle = useCallback(() => setCollapsed(!collapsed), [collapsed]);
+
+  return (
+    <ContextData.Provider value={collapsed}>
+      <ContextApi.Provider value={toggle}>{children}</ContextApi.Provider>
+    </ContextData.Provider>
+  );
+};
+
+export default NavController;
+```

--- a/React-Native/pages/pages/React/design-pattern/keyInMap.md
+++ b/React-Native/pages/pages/React/design-pattern/keyInMap.md
@@ -1,0 +1,64 @@
+### map()을 사용할 시, key에 index를 주지 않는 이유
+
+```jsx
+const data = [
+  { id: "teacher", placeholder: "teacher Id" },
+  { id: "student", placeholder: "student Id" },
+];
+
+const App = () => {
+  const [isChecked, setIsChecked] = useState(false);
+
+  const inputs = isChecked ? [...data].reverse() : data;
+  // 여기 있는 로직때문에 문제가 됨.
+  return (
+    <>
+      <input type="checkbox" onChange={() => setIsChecked(!isChecked)}>
+        check
+      </input>
+      {inputs.map((input, index) => {
+        <Input key={Index} placeholder={input} />;
+      })}
+    </>
+  );
+};
+```
+
+[Diffing](./Diffing.md)에서 정리한 내용에 따르면, 리액트는 객체에서 타입과 키가 같을 경우 새로 mount하지 않고 기존 컴포넌트를 사용한다.
+
+그런데 map을 통해 컴포넌트를 랜더링할 때 Key 값으로 index를 주면, 순서를 재정렬하거나 하는 경우에 각 data에 할당된 index가 달라진다.
+이 경우 리액트는 다른 컴포넌트라 생각해서 새롭게 mount를 진행한다. 그래서 이것을 방지하기 위해 보통 고유값인 Id을 Key값으로 할당한다.
+
+---
+
+#### 추가, dynamic rendering 아래에 같은 컴포넌트를 추가한다면??
+
+```jsx
+const App = () => {
+  const [isChecked, setIsChecked] = useState(false);
+  const inputs = isChecked ? [...data].reverse() : data;
+
+  return (
+    <>
+      {inputs.map((input, index) => {
+        <Input key={Index} placeholder={input} />;
+      })}
+      <Input />
+    </>
+  );
+};
+```
+
+리액트는 dynamic rendering을 사용한 컴포넌트의 경우 배열을 하나 더 만들어서 그안에 담음으로써 구분한다.
+
+```js
+[
+  [
+    {type: Input, key='a'},
+    {type: Input, key='b'},
+  ],
+  {type: Input},
+]
+```
+
+그래서 위치를 혼동하지 않는다.


### PR DESCRIPTION
### 날짜

- 2024-12-06

### 정리내용

- Diffing 내용 추가 
  - map으로 생성된 컴포넌트와 같은 컴포넌트를 추가한다면 리액트는 어떻게 구분하는가?
- Context
  - Context의 부작용에 대해서만 알고 있었다. 
  - 구독하는 컴포넌틑들이 모두 리렌더링이 발생하기에 굉장히 소극적으로 사용했었다.
  - 그러나 useCallback, useMemo, 그리고 Context splitting 패턴을 사용해서 대응할 수 있게 되었다.
  - 다만, useCallback과 useMemo는 여전히 참조값이 전달될 때나 dependency에 따른 에러가 있기에 Context splitting 패턴을 주로 사요할 것같다.
  - 여기에 useReduceRight로 Provider를 하나로 줄이면 그렇게 복잡하지 않으면서 렌더링 이슈를 해결할 컴포넌트 생성이 가능해 보인다.

---

- 함수형 프로그래밍과 리액트 디자인패턴 초반부를 공부할 때는 컴포넌트를 함수로 보는 시각을 가지게 되었다.
- 지금은 함수의 Return 값을 통해 예상과 다른 동작이 발생하는 이유와 그에 대한 대응방법을 배우는 것 같다.
- 확실히 영어 원문 강의라서 그런가 한국의 책이나 다른 강의들과 접근법이 상당히 다르다.
- 정확히 깊지도 그렇다고 얕지도 않게 정확히 필요한 부분만 알려주는데 엄청나게 도움된다.

- 근데 어렵다. 살려줘.
