### PR TITLE
2024-12-09

### DIFF
--- a/OOP/Index.md
+++ b/OOP/Index.md
@@ -27,3 +27,7 @@
 - [LSP](./pages/LSP.md)
 - [ISP](./pages/ISP.md)
 - [DIP](./pages/DIP.md)
+
+#### Creational Design Pattern
+
+- [Singleton Pattern](./pages/Singleton.md)

--- a/OOP/pages/Singleton.md
+++ b/OOP/pages/Singleton.md
@@ -1,0 +1,39 @@
+### Singleton
+
+- 클래스는 단 하나의 인스턴스만 가진다.
+- 그리고 전역 스코프에서 이 인스턴스에 접근 가능한다.
+- constructor는 Private method가 됨.
+- getInstance() method 존재
+
+```ts
+class Singleton {
+  private static instance: Singleton;
+
+  private static _value: number;
+
+  private constructor() {}
+
+  public static getInstance(): Singleton {
+    if (!Singleton.instance) {
+      Singleton.instance = new Singleton();
+    }
+
+    return Singleton.instance;
+  }
+
+  set value(value: number) {
+    Singleton._value = value;
+  }
+
+  get value() {
+    return Singleton._value;
+  }
+}
+```
+
+1. 전역 변수 사용할 때.
+
+- data cache, system wide configuration setting 등
+- 항상 예상 가능한 값을 가짐.
+
+2. 같은 객체를 계속 초기화를 진행할 때.

--- a/OOP/pages/Singleton.md
+++ b/OOP/pages/Singleton.md
@@ -37,3 +37,80 @@ class Singleton {
 - 항상 예상 가능한 값을 가짐.
 
 2. 같은 객체를 계속 초기화를 진행할 때.
+
+---
+
+#### 실습
+
+```ts
+// Singleton Logger Class
+// log method
+
+class Logger {
+  private static instance: Logger;
+
+  private constructor() {}
+
+  public static getInstance() {
+    if (!Logger.instance) {
+      Logger.instance = new Logger();
+    }
+
+    return Logger.instance;
+  }
+
+  public log(message: string): void {
+    const timestamp = new Date();
+    console.log(`[${timestamp.toLocaleString()} - ${message}]`);
+  }
+}
+
+const logger1 = Logger.getInstance();
+logger1.log("This is the first message");
+
+const logger2 = Logger.getInstance();
+logger2.log("This is the second message");
+```
+
+---
+
+#### 장점
+
+##### 1. 객체의 전역 상태 관리
+
+- 애플리케이션 전체에서 **단일 객체**를 공유하여 전역 상태를 관리할 수 있습니다.
+- 전역적으로 접근 가능한 로깅 시스템, 설정 관리, 데이터베이스 연결 등에 적합합니다.
+
+##### 2. 메모리 효율성
+
+- 단 하나의 객체만 생성되므로 **불필요한 메모리 소비**를 방지할 수 있습니다.
+- 여러 인스턴스를 생성할 때 발생하는 메모리 낭비를 줄입니다.
+
+##### 3. 일관된 접근성
+
+- 애플리케이션 전체에서 동일한 인스턴스를 사용하여 **일관된 데이터 접근**이 가능합니다.
+- 데이터 동기화 문제를 방지할 수 있습니다.
+
+##### 4. 초기화 제어
+
+- 객체 생성 시점을 명확히 제어할 수 있습니다.
+- **지연 초기화** 방식으로 필요할 때만 객체를 생성하므로, 애플리케이션 성능을 최적화할 수 있습니다.
+
+##### 5. 코드 간소화 및 유지보수성 향상
+
+- 단일 진입점을 보장하여 코드 구조가 간단해지고 유지보수가 용이합니다.
+- 분산된 객체 관리 대신 단일 객체를 참조하므로 디버깅과 확장 작업이 쉬워집니다.
+
+#### 싱글톤 패턴 활용 예
+
+- **로깅 시스템**: 동일한 로그 객체를 통해 로그 메시지를 기록.
+- **설정 관리**: 애플리케이션 전역에서 같은 설정을 참조.
+- **데이터베이스 연결**: 중복된 연결을 방지하고 단일 커넥션을 공유.
+- **캐싱**: 동일한 데이터를 여러 위치에서 참조할 수 있도록 공유 메모리 구현.
+
+---
+
+#### 참조
+
+- `this.instance`가 아닌 `Logger.instance`인 이유
+- static으로 선언해서 Logger.instance 로 접근하는 것이 일반적이며, static 임을 명시하기 위해 `Logger.instance`라고 씀.

--- a/OOP/practice.ts
+++ b/OOP/practice.ts
@@ -1,48 +1,23 @@
-interface GlobalState {
-  get<T>(key: string): T;
-  set(key: string, data: string): void;
-}
+class Singleton {
+  private static instance: Singleton;
 
-class ZustandStore implements GlobalState {
-  get<T>(key: string): T {
-    return useStore()[key];
-  }
-  set(key: string, data: string) {
-    useStore()[key](data);
-  }
-}
+  private static _value: number;
 
-class RecoilStore implements GlobalState {
-  get<T>(key: string): T {
-    return useRecoilValue(key);
+  private constructor() {}
+
+  public static getInstance(): Singleton {
+    if (!Singleton.instance) {
+      Singleton.instance = new Singleton();
+    }
+
+    return Singleton.instance;
   }
 
-  set(key: string, data: string) {
-    useSetRecoilState(key)(data);
-  }
-}
-
-const initialState = {
-  id: "123",
-  firstName: "John",
-  lastName: "Doe",
-};
-
-class SingleTone {
-  constructor(
-    private initialValue: typeof initialState,
-    private globalState: GlobalState
-  ) {}
-
-  getState(key: string) {
-    return this.globalState.get(key);
+  set value(value: number) {
+    Singleton._value = value;
   }
 
-  save(key: string, data: string) {
-    this.globalState.set(key, data);
+  get value() {
+    return Singleton._value;
   }
 }
-
-const test = new SingleTone(initialState, new ZustandStore());
-test.save("comment", "1111");
-test.getState("comment");

--- a/OOP/practice.ts
+++ b/OOP/practice.ts
@@ -1,23 +1,27 @@
-class Singleton {
-  private static instance: Singleton;
+// Singleton Logger Class
+// log method
 
-  private static _value: number;
+class Logger {
+  private static instance: Logger;
 
   private constructor() {}
 
-  public static getInstance(): Singleton {
-    if (!Singleton.instance) {
-      Singleton.instance = new Singleton();
+  public static getInstance() {
+    if (!Logger.instance) {
+      Logger.instance = new Logger();
     }
 
-    return Singleton.instance;
+    return Logger.instance;
   }
 
-  set value(value: number) {
-    Singleton._value = value;
-  }
-
-  get value() {
-    return Singleton._value;
+  public log(message: string): void {
+    const timestamp = new Date();
+    console.log(`[${timestamp.toLocaleString()} - ${message}]`);
   }
 }
+
+const logger1 = Logger.getInstance();
+logger1.log("This is the first message");
+
+const logger2 = Logger.getInstance();
+logger2.log("This is the second message");

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -78,6 +78,7 @@
 
 - [Context](./pages/React/design-pattern/Context.md)
 - [Wasted re-renders](./pages/React/design-pattern/WastedReRenders.md)
+- [Splitting context with useReducer](./pages/React/design-pattern/ContextWithReducer.md)
 
 #### extra
 

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -81,6 +81,10 @@
 - [Splitting context with useReducer](./pages/React/design-pattern/ContextWithReducer.md)
 - [Building a Selector](./pages/React/design-pattern/BuildingSelector.md)
 
+#### Ref
+
+- [Ref use-cases](./pages/React/design-pattern/Ref.md)
+
 #### extra
 
 - [ObserverPattern](./pages/React/design-pattern/ObserverPattern.md)

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -83,7 +83,7 @@
 
 #### Ref
 
-- [Ref use-cases](./pages/React/design-pattern/Ref.md)
+- [Ref](./pages/React/design-pattern/Ref.md)
 
 #### extra
 

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -79,6 +79,7 @@
 - [Context](./pages/React/design-pattern/Context.md)
 - [Wasted re-renders](./pages/React/design-pattern/WastedReRenders.md)
 - [Splitting context with useReducer](./pages/React/design-pattern/ContextWithReducer.md)
+- [Building a Selector](./pages/React/design-pattern/BuildingSelector.md)
 
 #### extra
 

--- a/React-Native/pages/pages/React/design-pattern/BuildingSelector.md
+++ b/React-Native/pages/pages/React/design-pattern/BuildingSelector.md
@@ -1,0 +1,28 @@
+### Building a Selector for Context Api
+
+- HOC 사용
+
+```jsx
+const withNavClose = (Component: any) => {
+  const MemoizedComponent = React.memo(Component);
+  return (props: any) => {
+    const { close } = useNav();
+
+    return <MemoizedComponent {...props} closeNav={close} />;
+  };
+};
+
+export default withNavClose;
+
+//Button.tsx
+
+export const CloseButton = withNavClose(
+  ({ closeNav }: { closeNav: () => void }) => {
+    return <ToggleButton onClick={closeNav}></ToggleButton>;
+  }
+);
+```
+
+- 이렇게 중간에서 메뫌 경우 같은 Prop이 내려온다 판단.
+- 리렌더링 방지
+- 전역상태 라이브러리에서 사용하는 useSelector 패턴과 비슷함.

--- a/React-Native/pages/pages/React/design-pattern/ContextWithReducer.md
+++ b/React-Native/pages/pages/React/design-pattern/ContextWithReducer.md
@@ -1,0 +1,74 @@
+### Splitting context with useReducer
+
+```jsx
+type State = { collapsed: boolean };
+
+const defaultSate: State = { collapsed: true };
+
+type Action = { type: "open" | "close" | "toggle" };
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "open":
+      return { ...state, collapsed: true };
+    case "close":
+      return { ...state, collapsed: false };
+    case "toggle":
+      return { ...state, collapsed: !state.collapsed };
+  }
+};
+
+const ContextData = React.createContext({
+  collapsed: false,
+});
+
+const ContextApi = React.createContext({
+  open: () => {},
+  close: () => {},
+  toggle: () => {},
+});
+
+const useNavData = () => useContext(ContextData);
+const useNavApi = () => useContext(ContextApi);
+
+const NavController = ({ children }: { children: ReactNode }) => {
+  const [state, dispatch] = useReducer(reducer, defaultState);
+
+  const data = useMemo(() => {
+    return { collapsed: state.collapsed };
+  }, [state]);
+
+  const api = useMemo(() => {
+    return {
+      open: () => dispatch({ type: "open" }),
+      close: () => dispatch({ type: "close" }),
+      toggle: () => dispatch({ type: "toggle" }),
+    };
+  }, []);
+
+  const toggle = useCallback(() => setCollapsed(!collapsed), [collapsed]);
+
+  return (
+    <ContextData.Provider value={collapsed}>
+      <ContextApi.Provider value={toggle}>{children}</ContextApi.Provider>
+    </ContextData.Provider>
+  );
+};
+
+export default NavController;
+```
+
+- useReducer를 사용할 경우 좀 더 유연하게 처리가 가능하다.
+
+예를 들어 state로 toggle을 구현한 경우
+
+```js
+const [state, setState] = useState(false);
+const toggle = useCallback(() => setState(!state), [state]);
+```
+
+setter함수를 사용하기 때문에 state에 의존성이 생긴다.
+
+결국 toggle이 state를 바꾸고 리렌더링을 유발한다. 그리고 useCallback의 dependency에 state을 추가했기 때문에 구독하 api를 구독하는 Provider에서 리렌더링을 유발한다.
+
+그래서 useReducer를 사용해서 useCallback을 useMemo로 전환하고 의존성을 제거하여 불필요한 리렌더링을 방지한다.

--- a/React-Native/pages/pages/React/design-pattern/Ref.md
+++ b/React-Native/pages/pages/React/design-pattern/Ref.md
@@ -1,0 +1,144 @@
+### Ref
+
+```js
+const idInput = document.getElementById("username-input");
+idInput.focus();
+```
+
+이걸 React에서는 Ref로 처리함.
+
+- 렌더링을 유발하지 않고 어딘가에 값을 저장할때 (timerId)
+- 직접 돔에 접근할 때 사용.
+- 그러나 ref를 통해서 리액트가 관리하는 돔을 직접 변경할 경우 충돌을 일으킬 수 있음
+
+```jsx
+const Test = () => {
+  const [show, setShow] = useState(true
+  const ref = useRef(null);
+
+  const handleWithState = () => setShow(!show);
+  const handleWithRef = () => ref.current.remove();
+
+  return (
+    <div>
+      <button onClick={handleWithState}>state</button>
+      <button onClick={handleWithRef}>ref</button>
+      {show && <p>some word</p>}
+    </div>
+  );
+};
+```
+
+- ref 버튼을 눌러서 직접 삭제하면 그 뒤로 다시 state 버튼을 누르면 에러가 발생한다.
+
+```jsx
+const Form = () => {
+  const [inputValue, setInputValue] = useState("");
+
+  const submit = () => {
+    console.log(inputValue);
+  };
+
+  const handleChangeWithState = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  return (
+    <>
+      <input type="text" onChange={handleChangeWithState} />
+      <button onClick={submit}>submit</button>
+    </>
+  );
+};
+```
+
+```jsx
+const Form = () => {
+  const ref = useRef("");
+
+  const submit = () => {
+    console.log(ref.current);
+  };
+
+  const handleChangeWithRef = (e: ChangeEvent<HTMLInputElement>) => {
+    ret.current = e.target.value;
+  };
+
+  return (
+    <>
+      <input type="text" onChange={handleChangeWithRef} />
+      <button onClick={submit}>submit</button>
+    </>
+  );
+};
+```
+
+이렇게 보면 2개 별 차이 없음.
+
+#### ref는 리렌더링을 유발하지 않는다.
+
+```jsx
+const Form = () => {
+  const ref = useRef("");
+  const charCount = ref.current.length || 0;
+
+  const submit = () => {
+    console.log(ref.current);
+  };
+
+  const handleChangeWithRef = (e: ChangeEvent<HTMLInputElement>) => {
+    ret.current = e.target.value;
+  };
+
+  return (
+    <div>
+      <input type="text" onChange={handleChangeWithRef} />
+      <button onClick={submit}>submit</button>
+      <h2>Number of Char: {charCount}</h2>
+    </div>
+  );
+};
+```
+
+리렌더링을 유발하지 않으므로 업데이트 되지않고 계속 0이 표시됨
+
+prop으로 전달되더라도 리렌더링 되지 않음 <br />
+-> 당연함(객체를 전달한 것이고 참조값은 변하지 않음) <br />
+-> 그럼 state는? state는 값이 변해야 하기 때문에 매번 새로운 state를 생성하는 중임
+
+```js
+const [state, setState] = useState({ a: 1 });
+// 동작 안함 같은 객체 참조값
+const increment = () => setState((prev) => (prev.a = prev.a + 1));
+// 동작, 다른 객체 참조값
+const increment = () =>
+  setState((prev) => {
+    return { ...prev, a: prev.a + 1 };
+  });
+```
+
+#### ref는 동기적으로 state는 비동기적으로 업데이트 됨다.
+
+- state를 업데이트하면 work를 scheduler에게 전달함.
+- 그 이후 Reconciler가 diffing 알고리즘과 함께 비교하며 내용을 업데이트함
+- 이후 commit phase까지 모두 거친다음 repaint가 수행됨.
+
+```js
+const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  console.log("before" + input);
+  setInput(e.target.value);
+  console.log("after" + input);
+};
+```
+
+이렇게 수행할 경우 handleChange가 실행된 시점에서 setInput이 비동기적으로 동작하기에 input은 업데이트 되지않음 값을 둘다 return함.
+
+```js
+const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  console.log("before" + ref.current);
+  ref.current = e.target.value;
+  console.log("after" + ref.current);
+};
+```
+
+이 경우 위 console.log와 아래의 console.log는 다른 값을 나타냄


### PR DESCRIPTION
### 날짜

- 2024-12-09

### 정리내용

- Context with reducer
  - reducer를 이용해서 cache 된 함수의 dependency를 제거함으로써 사용성 향상
  - state가 객체일 경우 수정할 때 reducer를 사용하는 것이 아무리 생각해도 훨씬 안전해 보임.
  - 초기 세팅만 복잡할 뿐

- Ref
  - state와 ref의 차이점
  - ref의 주 사용 예시
```js
const useRef = (initailState) => {
  const [state, _] = useState({current: initialState})

  return state 
}
```

결국 useState로도 구현가능하며 단지 setter함수를 안 써서 리렌더링만 유발 안 할 뿐 비슷함.

useMemo 와 useCallback 도 그렇고 useState와 useReducer, useRef로 그렇고 뭐이렇게 유연한지 서로가 서로를 구현할 수 있다.

난 리액트를 얼마나 알고 쓴걸까?

---

- Singleton
  - 본격적인 디자인 패턴
  - 이번에 공부해보니 객체를 지속적으로 객체를 초기화 할 경우 그것을 방지하기 위해서 쓴다고 한다.
  - 그럼 기존 작업에서 싱글턴을 불러오고 useEffect에서 cleanup function으로 초기화 했었는데 왜 굳이 싱글턴을 사용했을까?
  - 지금 생각해보면, react-native의 메모리 관리가 워낙 어렵기 때문에 이렇게 한게 아닐까 싶은데 다른 더 좋은 방법이 있지 않았을까 하는 의문이 든다.