### PR TITLE
2024-12-14

### DIFF
--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -98,6 +98,7 @@
 - [Error Boundary](./pages/React/design-pattern/ErrorBoundary.md)
 - [Keys Explained](./pages/React/design-pattern/KeysExplained.md)
 - [Event Listeners](./pages/React/design-pattern/EventListeners.md)
+- [useLayoutEffect](./pages/React/design-pattern/useLayoutEffect.md)
 
 #### extra
 

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -97,6 +97,7 @@
 - [React Portals](./pages/React/design-pattern/ReactPortals.md)
 - [Error Boundary](./pages/React/design-pattern/ErrorBoundary.md)
 - [Keys Explained](./pages/React/design-pattern/KeysExplained.md)
+- [Event Listeners](./pages/React/design-pattern/EventListeners.md)
 
 #### extra
 

--- a/React-Native/pages/pages/React/design-pattern/EventListeners.md
+++ b/React-Native/pages/pages/React/design-pattern/EventListeners.md
@@ -1,0 +1,12 @@
+### Event Listeners
+
+#### Event Bubbling
+
+- 한 요소에 이벤트가 발생하면, 이 요소에 할당된 핸들러가 동작하고, 이어서 부모 요소의 핸들러가 동작한다.
+- 그리고 가장 최상단의 조상 요소를 만날 때까지 이 과정이 반복되면서 요소 각각에 할당된 핸들러가 동작한다.
+
+#### Event Capturing
+
+- Event Bubbling이전에 발생한다.
+- Capturing -> target -> Bubbling 순서
+- `onClick` 대신에 `onClickCapture`를 사용하면 된다.

--- a/React-Native/pages/pages/React/design-pattern/useLayoutEffect.md
+++ b/React-Native/pages/pages/React/design-pattern/useLayoutEffect.md
@@ -1,0 +1,86 @@
+### useLayoutEffect
+
+```jsx
+function App() {
+  const [show, setShow] = useState(false);
+  const [top, setTop] = useState(0);
+  const buttonRef = useRef(null)
+
+  const useEffect(() => {
+    if (buttonRef.current === null || !show) return setTop(0);
+    const { bottom } = buttonRef.current.getBoundingClientRect();
+    setTop(bottom + 30);
+  }, [show])
+
+  return (
+    <div>
+      <button ref={buttonRef} onClick={() => setShow(!show)}>Show</button>
+      {show && (<div className="tooltip" style={{top: `${top}px`}}>some text</div>)}
+    </div>
+  )
+}
+
+export default App;
+```
+
+```js
+const [show, setShow] = useState(false);
+const [top, setTop] = useState(0);
+const buttonRef = useRef(null)
+
+const useEffect(() => {
+  if (buttonRef.current === null || !show) return setTop(0);
+  const { bottom } = buttonRef.current.getBoundingClientRect();
+  setTop(bottom + 30);
+}, [show])
+```
+
+이렇게 할 경우 렌더링 이후 useEffect에서 top을 계산하기 때문에 한번 지연이 발생한다.
+
+그리고 처음 top 값 0으로 나왔고 useEffect내의 `setTop()`이 다시 렌더링을 유발하며 top이 30이 된다.
+
+그래서 택스트 top부분 계산이 뭔가 `0->30`으로 이동하는 듯한 css버그가 발생한다.
+
+---
+
+#### useEffect
+
+리액트의 가장 대표적인 비동기 함수.
+
+외부 상태와 연결, 사이드 이펙트 다루기 등 여러가지 이론이 많지만, 위 내용에서는 **렌더링 이후 실행**되는 콜백함수라는것이 중요하다.
+
+즉, 렌더링이 완료되어야 한다.
+
+```jsx
+function App() {
+  const [show, setShow] = useState(false);
+  const [top, setTop] = useState(0);
+  const buttonRef = useRef(null)
+
+  const useEffect(() => {
+    if (buttonRef.current === null || !show) return setTop(0);
+    const { bottom } = buttonRef.current.getBoundingClientRect();
+    setTop(bottom + 30);
+  }, [show])
+
+  // 여기게 비즈니스 로직이 많아질 수록 useEffect 실행이 느려짐.
+  const now = performance.now()
+  while(i < performance.now() - 100) {
+    doSomething()
+  }
+
+  return ({/** 생략 */})
+}
+
+export default App;
+```
+
+이 경우, useLayoutEvent 를 사용한다.
+
+브라우저가 다시 화면을 그리기 전에 layout을 측정한다.
+
+즉, 렌더링 이후 실행되는 것이 아니라 렌더링 전에 이미 Top이 30이라는 값을 가지고 시작하게 된다.
+
+그래서 위 상황에서 발생헬 수 있는 에러가 방지됨다.
+
+그러나 성능 문제가 발생할 수 있으므로 왠만하면 useEffect 사용이 권장되며, layout버그 발생 시 useLayoutEffect로 전환한다.


### PR DESCRIPTION
### 날짜

- 2024-12-14

### 정리내용

- evnet listener
  - 간만에 버블링이랑 캡쳐링 복습
  - 1년이 지난 지금도 캡쳐링 사용하는거 볼 수가 없다.ㅋㅋ 
  - 차라리 ts의 decorator를 사용하면 사용했지..

- useLayoutEffect
  - 또박또박 작업시 사용했던 hook
  - 이때는 Header 작업시 사용했다.
  - useEffect로도 충불한 거 같았으나, 이상하게 개발환경에서 Header계산이 느려지는 버그가 발생해서, useLayoutEffect로 전환했었다.
  - 프로젝트를 할때, 불필요한 렌더링 방지를 위해 홀린 사람처럼 파생값만 사용했었는데, 이 경우 레이아웃 계산 식이 useEffect내에 들어갔으면, 한번 전환을 고려해봤을 거 같다.
  - 물론 그당시에는 useLayoutEfffect의 존재 유무도 몰랐지만 다행이 useEffect내에서 Ui 관련 이벤트가 잘 없어서 버그는 없었다.
  - 그래도 알고 안 쓰는 거랑 모르고 안쓴거랑 다르지 않은가ㅋㅋ 
