### PR TITLE
2024-12-16_2

### DIFF
--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -100,6 +100,7 @@
 - [Event Listeners](./pages/React/design-pattern/EventListeners.md)
 - [useLayoutEffect](./pages/React/design-pattern/useLayoutEffect.md)
 - [useId](./pages/React/design-pattern/useId.md)
+- [useCallback as Ref](./pages//React/design-pattern/useCallbackAsRef.md)
 
 #### extra
 

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -101,6 +101,7 @@
 - [useLayoutEffect](./pages/React/design-pattern/useLayoutEffect.md)
 - [useId](./pages/React/design-pattern/useId.md)
 - [useCallback as Ref](./pages//React/design-pattern/useCallbackAsRef.md)
+- [useDeferredValue](./pages/React/design-pattern/useDeferredValue.md)
 
 #### extra
 

--- a/React-Native/pages/index.md
+++ b/React-Native/pages/index.md
@@ -102,6 +102,7 @@
 - [useId](./pages/React/design-pattern/useId.md)
 - [useCallback as Ref](./pages//React/design-pattern/useCallbackAsRef.md)
 - [useDeferredValue](./pages/React/design-pattern/useDeferredValue.md)
+- [useTransition](./pages/React/design-pattern/useTransition.md)
 
 #### extra
 

--- a/React-Native/pages/pages/React/design-pattern/useCallbackAsRef.md
+++ b/React-Native/pages/pages/React/design-pattern/useCallbackAsRef.md
@@ -1,0 +1,88 @@
+### useCallback As Ref
+
+```jsx
+const App = () => {
+  const [showInput, setShowInput] = useState(false);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current.focus();
+  });
+
+  return (
+    <div>
+      <button onClick={() => setShowInput(!showInput)}>Switch</button>
+      {showInput && <input type="text" ref={inputRef} />}
+    </div>
+  );
+};
+
+export default App;
+```
+
+- 당연히 에러남.
+- 렌더링이 끝난후 showInput은 초기값이 false이기에 input은 아예 dom에 존재하지 않음.
+- `inputRef` 는 `null`임.
+- Null.current에 접근한 것임.
+
+```jsx
+const App = () => {
+  const [showInput, setShowInput] = useState(false);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    // 여기에 조건 추가
+    // early-return 주로 사용.
+    if (inputRef === null) return;
+    inputRef.current.focus();
+  });
+
+  return (
+    <div>
+      <button onClick={() => setShowInput(!showInput)}>Switch</button>
+      {showInput && <input type="text" ref={inputRef} />}
+    </div>
+  );
+};
+
+export default App;
+```
+
+그래서 inputRef가 있을때만 동작하도록 하면 됨.
+
+---
+
+근데 callback으로도 해결 가능
+
+```jsx
+const App = () => {
+  const [showInput, setShowInput] = useState(false);
+  const inputRef = useCallback((input) => {
+    if (input === null) return;
+    input.focus();
+  }, []);
+
+  return (
+    <div>
+      <button onClick={() => setShowInput(!showInput)}>Switch</button>
+      {showInput && <input type="text" ref={inputRef} />}
+    </div>
+  );
+};
+
+export default App;
+```
+
+---
+
+#### ???? ref에 함수전달하면 인수에 자동으로 dom 요소가 전달된다.
+
+```jsx
+const Test = () => {
+  const handleRef = (elem) => {
+    console.log(elem); // button node
+  };
+
+  return <button ref={handleRef}>Click</button>;
+};
+```

--- a/React-Native/pages/pages/React/design-pattern/useDeferredValue.md
+++ b/React-Native/pages/pages/React/design-pattern/useDeferredValue.md
@@ -1,0 +1,32 @@
+### useDeferredValue
+
+useDeferredValue는 UI 일부 업데이트를 지연시킬 수 있는 React Hook
+
+반환값: 초기 렌더링 중에는 반환된 ‘지연된 값’은 사용자가 제공한 값과 같다. 업데이트가 발생하면 React는 먼저 이전 값으로 리렌더링을 시도(반환값이 이전 값과 일치하도록)하고, 그다음 백그라운드에서 다시 새 값으로 리렌더링을 시도(반환값이 업데이트된 새 값과 일치하도록)한다.
+
+즉
+
+```js
+const [state, setState] = useState("12");
+const deferredValue = useDeferredValue(state);
+```
+
+이 경우 처음 렌더링 시 state값은 초기값과 일치하지만, setState로 state가 업데이트 될 시, deferredValue에서는 일단 초기값을 유지하고 천천히 업데이트 한다.
+
+그래서 무거운 컴포넌트와 같이 쓸 때, 그리고 컴포넌트에게 prop까지 전달할 경우 deferredValue를 사용한다.
+
+```jsx
+const MemoedHeavyComp = memo(HeavyComp);
+
+const App = () => {
+  const [state, setState] = useState("12");
+  const deferredValue = useDeferredValue(state);
+
+  return (
+    <Fragment>
+      <input value={state} onChange={(e) => setState(e.target.value)} />
+      <MemoedHeavyCom input={state} />
+    </Fragment>
+  );
+};
+```

--- a/React-Native/pages/pages/React/design-pattern/useTransition.md
+++ b/React-Native/pages/pages/React/design-pattern/useTransition.md
@@ -1,0 +1,36 @@
+### useTransition
+
+`useTransition`은 UI를 차단하지 않고 상태를 업데이트할 수 있는 React Hook
+
+`useDeferredValue`와 다르게 값을 함수의 실행다룬다.
+
+```jsx
+const App = () => {
+  const [state, setState] = useState("state");
+  const [isPending, startTransition] = useTransition();
+
+  const HandleState = (newState: string) => {
+    startTransition(() => {
+      setState(newState);
+    });
+  };
+};
+```
+
+이렇게 되면 setState를 transition 상태로 둔다.
+
+그리고 transition 상태하에 있는 경우를 판단할 때 `isPending`을 사용한다.
+
+반드시 동기적인 코드를 사용해야 한다.
+
+```jsx
+const HandleState = (newState: string) => {
+  startTransition(() => {
+    setTimeout(() => {
+      setState(newState);
+    }, 10);
+  });
+};
+```
+
+이러면 startTransition이 동작하지 않음.


### PR DESCRIPTION
### 날짜

- 2024-12-16_2

### 정리내용

- useCallback as ref
  - 내 살다살다 ref attr에 함수 할당하면 인수로 dom element가 전달되는거 처음 알았네.
  - Class 형 컴포넌트 시절에는 이런 느낌처럼 할당해서 익숙하다고 하는데
  - 참... 

- useDeferredValue
- useTransiton
  - 두 개는 세트같다.
  - 이 두개는 Ui의 끊김에 의한 사용자의 불편함을 해결하기 위해 만들어 졌다.
  - 새삼 React가 ui를 쉽게 처리하기 위한 라이브러리 였다는 것이 생각난다.
  - 지금은 워낙에 React를 다들 쓰니까 이유 없이 그냥 사용하는 분위기이다.
  - React는 어떠한 문제를 직면했고 어떤 문제들을 해결해왔는지 이제는 역사가 궁금하다.